### PR TITLE
加入编译结果缓存

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.lastcompiled.Dmk.cpp .lastcompiled.Main.cpp .lastcompiled.Std.cpp


### PR DESCRIPTION
很多情况下有些文件并没有被修改，但每次运行 `Checker` 都需要重新编译四个文件，会造成不必要的开销。
因此我试着加入了这个功能。
